### PR TITLE
Revise layout

### DIFF
--- a/www/css/style.css
+++ b/www/css/style.css
@@ -18,16 +18,16 @@
 
 .circle {
     background-color: white;
-    width: 100px;
-    height: 100px;
+    width: 85px;
+    height: 85px;
     border-radius: 50%;
-    margin: 25px;
+    margin: 20px;
     margin-bottom: 10px;
     margin-top: 10px;
 }
 
 .circle > .icon {
-    top: 28px;
+    top: 22px;
     position: relative;
     font-size: 40px;
     color: #387ef5;

--- a/www/index.html
+++ b/www/index.html
@@ -57,7 +57,7 @@
     </script>
 
     <script id="templates/home.html" type="text/ng-template">
-        <ion-view class="home" view-title="San Jose 311">
+        <ion-view class="home" view-title="">
         <ion-content class="padding">
             <div class="circle-row">
                 <div class="circle-container">


### PR DESCRIPTION
1. Revise home page icon size for 320 width phones.
2. Remove title show at navigation back button to prevent text overlapping on smaller phones
